### PR TITLE
Add tests and CI for reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - run: python -m pip install -r requirements.txt -r requirements-dev.txt
+      - run: ruff check .
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - run: python -m pip install -r requirements.txt -r requirements-dev.txt
+      - run: mypy .
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: python -m pip install -r requirements.txt -r requirements-dev.txt
+      - run: pytest --cov=. --cov-fail-under=90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+hypothesis
+mypy
+ruff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path for test imports
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tests/test_get_dataloaders.py
+++ b/tests/test_get_dataloaders.py
@@ -1,0 +1,74 @@
+import torch
+import torchvision
+import pytest
+
+from main import get_dataloaders
+
+
+def _fake_dataset_factory(channels: int, height: int, width: int, train_size: int, test_size: int):
+    class _FakeDataset(torchvision.datasets.FakeData):
+        def __init__(self, root=None, train: bool = True, download: bool = False, transform=None):
+            size = train_size if train else test_size
+            super().__init__(
+                size=size,
+                image_size=(channels, height, width),
+                num_classes=10,
+                transform=transform,
+            )
+
+    return _FakeDataset
+
+
+@pytest.fixture(autouse=True)
+def patch_datasets_and_loader(monkeypatch):
+    monkeypatch.setattr(
+        torchvision.datasets,
+        "MNIST",
+        _fake_dataset_factory(1, 28, 28, 60000, 10000),
+    )
+    monkeypatch.setattr(
+        torchvision.datasets,
+        "CIFAR10",
+        _fake_dataset_factory(3, 32, 32, 50000, 10000),
+    )
+
+    original_loader = torch.utils.data.DataLoader
+
+    def _loader(*args, **kwargs):
+        kwargs["num_workers"] = 0
+        return original_loader(*args, **kwargs)
+
+    monkeypatch.setattr(torch.utils.data, "DataLoader", _loader)
+
+
+def _assert_batch(
+    loader: torch.utils.data.DataLoader,
+    channels: int,
+    height: int,
+    width: int,
+    batch_size: int,
+):
+    images, labels = next(iter(loader))
+    assert images.shape == (batch_size, channels, height, width)
+    assert images.dtype == torch.float32
+    assert labels.shape == (batch_size,)
+    assert labels.dtype == torch.int64
+
+
+def test_get_dataloaders_mnist():
+    train, val, test = get_dataloaders("MNIST", batch_size=4)
+    _assert_batch(train, 1, 28, 28, 4)
+    _assert_batch(val, 1, 28, 28, 4)
+    _assert_batch(test, 1, 28, 28, 4)
+
+
+def test_get_dataloaders_cifar10():
+    train, val, _ = get_dataloaders("CIFAR10", batch_size=4)
+    _assert_batch(train, 3, 32, 32, 4)
+    _assert_batch(val, 3, 32, 32, 4)
+
+
+def test_get_dataloaders_invalid_dataset():
+    with pytest.raises(ValueError):
+        get_dataloaders("INVALID", 32)
+

--- a/tests/test_plot_results.py
+++ b/tests/test_plot_results.py
@@ -1,0 +1,19 @@
+import os
+
+from main import plot_results
+
+
+def test_plot_results_creates_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    results = {
+        "MNIST_SGD": {
+            "train_loss": [1.0, 0.5],
+            "val_loss": [1.0, 0.5],
+            "val_acc": [50.0, 60.0],
+            "test_loss": 0.5,
+            "test_acc": 60.0,
+            "training_time": 1.0,
+        }
+    }
+    plot_results(results, ["MNIST"], ["SGD"])
+    assert os.path.exists(tmp_path / "optimizer_comparison.png")

--- a/tests/test_simplecnn.py
+++ b/tests/test_simplecnn.py
@@ -1,0 +1,24 @@
+import torch
+from hypothesis import given, strategies as st
+
+from main import SimpleCNN
+
+
+@st.composite
+def image_batches(draw):
+    batch = draw(st.integers(min_value=1, max_value=4))
+    channels = draw(st.sampled_from([1, 3]))
+    if channels == 1:
+        x = torch.randn(batch, 1, 28, 28)
+    else:
+        x = torch.randn(batch, 3, 32, 32)
+    return x, channels
+
+
+@given(image_batches())
+def test_simplecnn_forward_output(image_data):
+    x, channels = image_data
+    model = SimpleCNN(num_classes=10, input_channels=channels)
+    out = model(x)
+    assert out.shape == (x.shape[0], 10)
+    assert torch.isfinite(out).all()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+from hypothesis import given, strategies as st
+import pytest
+
+from main import SimpleCNN, train_one_epoch, evaluate
+
+
+def _constant_dataset(size: int):
+    inputs = torch.randn(size, 1, 28, 28)
+    targets = torch.zeros(size, dtype=torch.long)
+    return DataLoader(TensorDataset(inputs, targets), batch_size=max(1, size // 2))
+
+
+def test_train_one_epoch_updates_parameters():
+    model = SimpleCNN(num_classes=10, input_channels=1)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    loader = _constant_dataset(8)
+    params_before = [p.clone() for p in model.parameters()]
+    loss = train_one_epoch(model, loader, optimizer, criterion, torch.device("cpu"))
+    params_after = list(model.parameters())
+    assert loss >= 0
+    assert any(not torch.equal(a, b) for a, b in zip(params_before, params_after))
+
+
+class ConstantModel(nn.Module):
+    def __init__(self, label: int = 0):
+        super().__init__()
+        self.label = label
+
+    def forward(self, x):
+        out = torch.zeros(x.size(0), 10)
+        out[:, self.label] = 1.0
+        return out
+
+
+@given(st.integers(min_value=1, max_value=5))
+def test_evaluate_perfect_accuracy(batch):
+    model = ConstantModel(label=0)
+    criterion = nn.CrossEntropyLoss()
+    loader = _constant_dataset(batch)
+    loss, acc = evaluate(model, loader, criterion, torch.device("cpu"))
+    assert acc == 100.0
+
+
+def test_evaluate_empty_dataloader_raises():
+    model = ConstantModel(label=0)
+    criterion = nn.CrossEntropyLoss()
+    empty_loader = DataLoader(
+        TensorDataset(torch.empty(0, 1, 28, 28), torch.empty(0, dtype=torch.long)),
+        batch_size=1,
+    )
+    with pytest.raises(ValueError):
+        evaluate(model, empty_loader, criterion, torch.device("cpu"))


### PR DESCRIPTION
## Summary
- add pytest suite with hypothesis-based and regression tests
- integrate GitHub Actions matrix CI with lint, type check, and coverage gate
- handle empty dataloader in `evaluate` and refactor script entry point
- run `ruff check .` in CI to avoid CLI subcommand error
- mock dataset downloads and force serial DataLoader for `get_dataloaders` tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest --cov=. --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68acbbabc6b48323b9bf7dc9c00f553f