### PR TITLE
Enhance library reliability with utility helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a PyTorch implementation for comparing three optimizati
 - Comprehensive comparison of optimization algorithms
 - Visualization of training dynamics and performance metrics
 - macOS-friendly defaults including support for Apple's Metal (MPS) backend and single-process data loading
+- Helper functions for reproducible experiments and device selection
 
 ## Requirements
 
@@ -41,6 +42,14 @@ This will:
 2. Use three different optimizers (SGD, Adam, PSD)
 3. Generate comparison plots of training metrics
 4. Save results to optimizer_comparison.png
+
+## Utility Functions
+
+The project includes small utility helpers to make experiments more reliable:
+
+- `set_seed(seed)` – configure random seeds across libraries for reproducibility.
+- `get_device()` – automatically choose between CUDA, Apple's MPS, or CPU.
+- `create_optimizer(name, params)` – build a configured optimizer and validate its name.
 
 ## Results
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -25,6 +25,18 @@ def test_train_one_epoch_updates_parameters():
     assert any(not torch.equal(a, b) for a, b in zip(params_before, params_after))
 
 
+def test_train_one_epoch_empty_dataloader_raises():
+    model = SimpleCNN(num_classes=10, input_channels=1)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    empty_loader = DataLoader(
+        TensorDataset(torch.empty(0, 1, 28, 28), torch.empty(0, dtype=torch.long)),
+        batch_size=1,
+    )
+    with pytest.raises(ValueError):
+        train_one_epoch(model, empty_loader, optimizer, criterion, torch.device("cpu"))
+
+
 class ConstantModel(nn.Module):
     def __init__(self, label: int = 0):
         super().__init__()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import numpy as np
+import torch
+import pytest
+
+from utils import set_seed, get_device
+from main import create_optimizer, SimpleCNN
+
+
+def test_set_seed_reproducible():
+    set_seed(123)
+    a1 = torch.rand(2)
+    b1 = np.random.rand(2)
+    set_seed(123)
+    a2 = torch.rand(2)
+    b2 = np.random.rand(2)
+    assert torch.equal(a1, a2)
+    assert np.allclose(b1, b2)
+
+
+def test_get_device_returns_torch_device():
+    device = get_device()
+    assert isinstance(device, torch.device)
+
+
+def test_create_optimizer_invalid_name():
+    model = SimpleCNN(num_classes=10, input_channels=1)
+    with pytest.raises(ValueError):
+        create_optimizer("INVALID", model.parameters())

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import random
+import numpy as np
+import torch
+
+
+def set_seed(seed: int) -> None:
+    """Set random seeds for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def get_device() -> torch.device:
+    """Select the best available compute device."""
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")


### PR DESCRIPTION
## Summary
- Add `set_seed` and `get_device` utilities for reproducible and portable experiments
- Introduce `create_optimizer` and dataloader validation to make training more robust
- Document new helpers and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3574f7948323a937c2f5faac4db1